### PR TITLE
Fix build issues in CI pipeline

### DIFF
--- a/template/{{.project_name}}/pyproject.toml.tmpl
+++ b/template/{{.project_name}}/pyproject.toml.tmpl
@@ -1,5 +1,5 @@
 [project]
-name = "{{.project_name}}"
+name = "{{.package_name}}"
 version = "0.1.0"
 description = "{{.description}}"
 authors = [


### PR DESCRIPTION
# Description

Renaming `name = "{{.project_name}}"` to `name = "{{.package_name}}"` in `pyproject.toml`, mitigating build issues in CI pipeline. 

## Issues

<!-- Link to the issue or tickets that this PR addresses -->

## Checklist

- [ ] Documented
- [x] Tested
